### PR TITLE
Fix restart of dnsmasq.service in module update

### DIFF
--- a/imageroot/update-module.d/10setup
+++ b/imageroot/update-module.d/10setup
@@ -15,5 +15,5 @@ mkdir -p dnsmasq.d dnsmasq_hosts.d
 # Install systemd service
 install -m 644 ../dnsmasq.service "/etc/systemd/system/${MODULE_ID}.service"
 systemctl daemon-reload
-# restart service only if it's already running
-systemctl try-restart "${MODULE_ID}"
+# Restart the service, if the module has been configured:
+systemctl -q is-enabled "${MODULE_ID}" && systemctl restart -T "${MODULE_ID}"


### PR DESCRIPTION
Even if the service is in failed state, a restart must be attempted.

Skip the start/restart only if the service is disabled, typically because the module is still unconfigured.


Refs https://github.com/NethServer/dev/issues/6959