### PR TITLE
Fix regression of bugfix 6959

### DIFF
--- a/imageroot/update-module.d/10setup
+++ b/imageroot/update-module.d/10setup
@@ -16,4 +16,6 @@ mkdir -p dnsmasq.d dnsmasq_hosts.d
 install -m 644 ../dnsmasq.service "/etc/systemd/system/${MODULE_ID}.service"
 systemctl daemon-reload
 # Restart the service, if the module has been configured:
-systemctl -q is-enabled "${MODULE_ID}" && systemctl restart -T "${MODULE_ID}"
+if systemctl -q is-enabled "${MODULE_ID}"; then
+    systemctl restart -T "${MODULE_ID}"
+fi


### PR DESCRIPTION
The 10setup script terminates with a non-zero exit code at module installation time.

The shell AND causes a non-zero exit code if the service is not enabled.

Refs NethServer/dev#6959