### PR TITLE
feat(ns8): add DNS server running check and disabled dns toggle

### DIFF
--- a/imageroot/actions/configure-module/10validate
+++ b/imageroot/actions/configure-module/10validate
@@ -63,3 +63,14 @@ if request["dhcp-server"]["enabled"]:
         agent.set_status('validation-failed')
         json.dump([{'field':'dhcp-server.start', 'parameter':'dhcp-server.start','value': request['dhcp-server']['start'], 'error':'must_be_less_than_end'}], fp=sys.stdout)
         sys.exit(2)
+
+if request["dns-server"]["enabled"]:
+    are_dns_bound = network.are_ports_53_bound()
+    # read config.json and determine if dns is used for this instance
+    config = json.load(open("config.json"))
+    is_dns_enabled = config["dns-server"]["enabled"]
+    # check if dns is already bound to port 53 and stop the action
+    if are_dns_bound and not is_dns_enabled:
+        agent.set_status('validation-failed')
+        json.dump([{'field':'dnsEnableField', 'parameter':'dnsEnableField', 'value': request['dns-server']['enabled'], 'error':'dns_port_already_bind'}], fp=sys.stdout)
+        sys.exit(3)

--- a/imageroot/actions/configure-module/10validate
+++ b/imageroot/actions/configure-module/10validate
@@ -65,12 +65,12 @@ if request["dhcp-server"]["enabled"]:
         sys.exit(2)
 
 if request["dns-server"]["enabled"]:
-    are_dns_bound = network.are_ports_53_bound()
+    is_dns_bound = network.are_ports_53_bound()
     # read config.json and determine if dns is used for this instance
     config = json.load(open("config.json"))
     is_dns_enabled = config["dns-server"]["enabled"]
     # check if dns is already bound to port 53 and stop the action
-    if are_dns_bound and not is_dns_enabled:
+    if is_dns_bound and not is_dns_enabled:
         agent.set_status('validation-failed')
         json.dump([{'field':'dnsEnableField', 'parameter':'dnsEnableField', 'value': request['dns-server']['enabled'], 'error':'dns_port_already_bind'}], fp=sys.stdout)
         sys.exit(3)

--- a/imageroot/actions/get-configuration/10get
+++ b/imageroot/actions/get-configuration/10get
@@ -18,4 +18,10 @@ if config["interface"] != "" and config["dhcp-server"]["start"] == "" and config
     config["dhcp-server"]["start"] = str(interface["start"])
     config["dhcp-server"]["end"] = str(interface["end"])
 
+# we test if tcp/53 or udp/53 is bound to the interface
+config["are_dns_bound"] = network.are_ports_53_bound()
+# check if dnsmasq is enabled in the configuration, needed to determine in the UI if the DNS server was enabled and used by dnsmasq.
+# the dnsmasq service is always running, we cannot state if it is enabled/active or not.
+config['is_dns_enabled'] = config["dns-server"]["enabled"]
+
 json.dump(config, sys.stdout)

--- a/imageroot/actions/get-configuration/10get
+++ b/imageroot/actions/get-configuration/10get
@@ -19,7 +19,7 @@ if config["interface"] != "" and config["dhcp-server"]["start"] == "" and config
     config["dhcp-server"]["end"] = str(interface["end"])
 
 # we test if tcp/53 or udp/53 is bound to the interface
-config["are_dns_bound"] = network.are_ports_53_bound()
+config["is_dns_bound"] = network.are_ports_53_bound()
 # check if dnsmasq is enabled in the configuration, needed to determine in the UI if the DNS server was enabled and used by dnsmasq.
 # the dnsmasq service is always running, we cannot state if it is enabled/active or not.
 config['is_dns_enabled'] = config["dns-server"]["enabled"]

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -101,7 +101,7 @@
             "description": "True if dnsmasq is configured",
             "type": "boolean"
         },
-        "are_dns_bound": {
+        "is_dns_bound": {
             "description": "True if DNS servers are bound to the interface",
             "type": "boolean"
         }
@@ -111,6 +111,6 @@
         "dhcp-server",
         "dns-server",
         "is_dns_enabled",
-        "are_dns_bound"
+        "is_dns_bound"
     ]
 }

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -96,11 +96,21 @@
                 "primary-server",
                 "secondary-server"
             ]
+        },
+        "is_dns_enabled": {
+            "description": "True if dnsmasq is configured",
+            "type": "boolean"
+        },
+        "are_dns_bound": {
+            "description": "True if DNS servers are bound to the interface",
+            "type": "boolean"
         }
     },
     "required": [
         "interface",
         "dhcp-server",
-        "dns-server"
+        "dns-server",
+        "is_dns_enabled",
+        "are_dns_bound"
     ]
 }

--- a/imageroot/pypkg/network.py
+++ b/imageroot/pypkg/network.py
@@ -8,6 +8,7 @@
 import ipaddress
 import json
 import subprocess
+import socket
 
 
 def __filter_interface(interface):
@@ -59,3 +60,21 @@ def list_interfaces():
     """
     subprocess_result = subprocess.run(["ip", "-4", "-j", "addr"], check=True, capture_output=True)
     return [__format_interface(interface) for interface in json.loads(subprocess_result.stdout) if __filter_interface(interface)]
+
+def __is_port_bound(port, protocol, ip='127.0.0.1'):
+    """
+    Check if a port is already bound for a given protocol (TCP/UDP) on a specific IP address.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM if protocol == 'tcp' else socket.SOCK_DGRAM)
+    try:
+        s.bind((ip, port))
+        s.close()
+        return False
+    except OSError:
+        return True
+
+def are_ports_53_bound(ip='127.0.0.1'):
+    """
+    Check if both TCP and UDP ports 53 are bound on a specific IP address.
+    """
+    return __is_port_bound(53, 'tcp', ip) or __is_port_bound(53, 'udp', ip)

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -53,7 +53,9 @@
         "dhcp-server_invalid_type": "Number required",
         "dhcp-server_number_gte": "Enter a positive number",
         "dns-server_format": "IPv4 format required",
-        "dns-server_number_one_of": "IPv4 or IPv6 required"
+        "dns-server_number_one_of": "IPv4 or IPv6 required",
+        "dns_server_is_running": "A DNS server is running",
+        "dns_server_is_running_description": "You cannot configure the dns feature if a DNS server is already running on this node. A module like samba may be using the DNS port."
     },
     "dns_records": {
         "title": "DNS records",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -54,8 +54,8 @@
         "dhcp-server_number_gte": "Enter a positive number",
         "dns-server_format": "IPv4 format required",
         "dns-server_number_one_of": "IPv4 or IPv6 required",
-        "dns_server_is_running": "A DNS server is running",
-        "dns_server_is_running_description": "You cannot configure the dns feature if a DNS server is already running on this node. A module like samba may be using the DNS port."
+        "dns_server_is_running": "A DNS server is currently running",
+        "dns_server_is_running_description": "You cannot enable the DNS feature because a DNS server is already active on this node. Another application, such as Samba DC, might be using the DNS port."
     },
     "dns_records": {
         "title": "DNS records",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -162,11 +162,28 @@
                 <div class="title-description mg-bottom-xlg">
                   {{ $t("settings.DNS_description") }}
                 </div>
+                <cv-row
+                  v-if="are_dns_bound && !dnsEnableField && !is_dns_enabled"
+                >
+                  <cv-column>
+                    <NsInlineNotification
+                      kind="info"
+                      :title="$t('settings.dns_server_is_running')"
+                      :description="
+                        $t('settings.dns_server_is_running_description')
+                      "
+                      :showCloseButton="false"
+                    />
+                  </cv-column>
+                </cv-row>
                 <NsToggle
                   :label="$t('settings.DNS_enable_label')"
                   v-model="dnsEnableField"
                   value="dnsEnableField"
                   formItem
+                  :disabled="
+                    are_dns_bound && !dnsEnableField && !is_dns_enabled
+                  "
                   ref="dnsEnableField"
                 >
                   <template slot="text-left">{{
@@ -201,7 +218,9 @@
                   :icon="Save20"
                   :loading="loading.configureModule"
                   :disabled="
-                    loading.getConfiguration || loading.configureModule
+                    loading.getConfiguration ||
+                    loading.configureModule ||
+                    (are_dns_bound && !dnsEnableField && !is_dns_enabled)
                   "
                   >{{ $t("settings.save") }}</NsButton
                 >
@@ -250,6 +269,8 @@ export default {
       dhcpStartField: "",
       dhcpEndField: "",
       dhcpLeaseField: 12,
+      are_dns_bound: false,
+      is_dns_enabled: false,
       dnsEnableField: false,
       dnsPrimaryField: "",
       dnsSecondaryField: "",
@@ -406,6 +427,8 @@ export default {
       this.dnsEnableField = dns_server["enabled"];
       this.dnsPrimaryField = dns_server["primary-server"];
       this.dnsSecondaryField = dns_server["secondary-server"];
+      this.are_dns_bound = config["are_dns_bound"];
+      this.is_dns_enabled = config["is_dns_enabled"];
     },
     validateConfigureModule() {
       this.clearErrors(this);

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -163,7 +163,7 @@
                   {{ $t("settings.DNS_description") }}
                 </div>
                 <cv-row
-                  v-if="are_dns_bound && !dnsEnableField && !is_dns_enabled"
+                  v-if="is_dns_bound && !dnsEnableField && !is_dns_enabled"
                 >
                   <cv-column>
                     <NsInlineNotification
@@ -182,7 +182,7 @@
                   value="dnsEnableField"
                   formItem
                   :disabled="
-                    are_dns_bound && !dnsEnableField && !is_dns_enabled
+                    is_dns_bound && !dnsEnableField && !is_dns_enabled
                   "
                   ref="dnsEnableField"
                 >
@@ -220,7 +220,7 @@
                   :disabled="
                     loading.getConfiguration ||
                     loading.configureModule ||
-                    (are_dns_bound && !dnsEnableField && !is_dns_enabled)
+                    (is_dns_bound && !dnsEnableField && !is_dns_enabled)
                   "
                   >{{ $t("settings.save") }}</NsButton
                 >
@@ -269,7 +269,7 @@ export default {
       dhcpStartField: "",
       dhcpEndField: "",
       dhcpLeaseField: 12,
-      are_dns_bound: false,
+      is_dns_bound: false,
       is_dns_enabled: false,
       dnsEnableField: false,
       dnsPrimaryField: "",
@@ -427,7 +427,7 @@ export default {
       this.dnsEnableField = dns_server["enabled"];
       this.dnsPrimaryField = dns_server["primary-server"];
       this.dnsSecondaryField = dns_server["secondary-server"];
-      this.are_dns_bound = config["are_dns_bound"];
+      this.is_dns_bound = config["is_dns_bound"];
       this.is_dns_enabled = config["is_dns_enabled"];
     },
     validateConfigureModule() {


### PR DESCRIPTION
Implement a check in the UI to verify if the tcp/53 or the udp/53 is not already used. The toggle and the button is disabled when the check is true. 

The test should take care that the dns ports are used from another instances, we test if the dnsmasq configuration is set to False: dns-server.enabled == False

![image](https://github.com/user-attachments/assets/f312f99d-f80f-494e-9561-4ea3a48bcfd6)


https://github.com/NethServer/dev/issues/6982